### PR TITLE
Fix environmentTools method name

### DIFF
--- a/mcp-server/src/main/java/com/cyster/mcp/McpServer.java
+++ b/mcp-server/src/main/java/com/cyster/mcp/McpServer.java
@@ -13,7 +13,7 @@ public class McpServer {
     }
 
     @Bean
-    public ToolCallbackProvider environentTools(WeatherService weatherService, ToolContextService environmentService) {
+    public ToolCallbackProvider environmentTools(WeatherService weatherService, ToolContextService environmentService) {
         return MethodToolCallbackProvider.builder().toolObjects(weatherService, environmentService).build();
     }
         


### PR DESCRIPTION
## Summary
- fix typo in McpServer bean method name from `environentTools` to `environmentTools`

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68438cbf41c48328a49c859bcf258863