### PR TITLE
Refine global error handling

### DIFF
--- a/chat-server/src/test/java/com/cyster/chat/ChatExceptionHandlerTest.java
+++ b/chat-server/src/test/java/com/cyster/chat/ChatExceptionHandlerTest.java
@@ -1,0 +1,39 @@
+package com.cyster.chat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.tool.ToolCallbackProvider;
+
+@WebFluxTest(ChatController.class)
+@Import(RestExceptionHandler.class)
+class ChatExceptionHandlerTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockBean
+    ChatModel chatModel;
+
+    @MockBean
+    ToolCallbackProvider toolCallbackProvider;
+
+    @Test
+    void missingPromptReturnsErrorResponse() {
+        webTestClient.post().uri("/chat")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{\"prompt\":\"\"}")
+            .exchange()
+            .expectStatus().isBadRequest()
+            .expectBody()
+            .jsonPath("$.httpStatusCode").isEqualTo(400)
+            .jsonPath("$.code").isEqualTo("PROMPT_MISSING")
+            .jsonPath("$.message").isEqualTo("No prompt was specified");
+    }
+}


### PR DESCRIPTION
## Summary
- map all RestException subtypes through the same handler
- wrap any unexpected exceptions in a generic 500 response
- update WebFlux test to expect RestErrorResponse

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68438ccd6f108328b17a0e177239cc18