### PR TITLE
Add Nix setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Repo Guidelines for Codex
+
+## Nix Setup
+
+To build or test this project, first install Nix and update channels:
+
+```bash
+apt-get update && apt-get install -y nix-bin
+nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
+nix-channel --update
+```
+
+Use `nix-shell shell.nix` to enter the development environment. **All** `gradle` commands must run inside this shell.
+
+## Gradle Commands
+
+Common commands run inside the shell:
+
+- `gradle test`
+- `gradle :mcp-app:bootJar`
+- `gradle :mcp-server:runMcpTestSse`
+- `gradle :mcp-server:runMcpTestStdio`
+
+These are the test commands used locally and should be executed within the Nix environment.


### PR DESCRIPTION
## Summary
- add repo root AGENTS file with instructions to install Nix and run gradle in a nix-shell

## Testing
- `apt-get update && apt-get install -y nix-bin`
- `nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs`
- `nix-channel --update`
- `nix-shell shell.nix --run "gradle test --dry-run"` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684497315dcc832898899ce6b0775b20