### PR TITLE
Configure JUnit platform for module tests

### DIFF
--- a/chat-flux-server/build.gradle
+++ b/chat-flux-server/build.gradle
@@ -16,3 +16,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/mcp-server/build.gradle
+++ b/mcp-server/build.gradle
@@ -8,6 +8,10 @@ dependencies {
    implementation "org.springframework.ai:spring-ai-starter-mcp-server-webflux"
 }
 
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
 tasks.register("runMcpTestSse", JavaExec) {
     group = "application"
     description = "Launch the SSE test client from test sources"


### PR DESCRIPTION
## Summary
- enable JUnit platform in `chat-flux-server`
- enable JUnit platform in `mcp-server`

## Testing
- `nix-shell shell.nix --run "./gradlew test > /tmp/gradle-test.log && tail -n 20 /tmp/gradle-test.log"` *(fails: interrupted because the environment download is too heavy)*

------
https://chatgpt.com/codex/tasks/task_e_68449d366e788328aec1e5863f20491a