### PR TITLE
Update RestException uniqueId behavior

### DIFF
--- a/chat-flux-server/src/main/java/com/cyster/flux/chat/RestException.java
+++ b/chat-flux-server/src/main/java/com/cyster/flux/chat/RestException.java
@@ -5,12 +5,14 @@ import java.util.Map;
 import java.util.UUID;
 
 public class RestException extends RuntimeException {
+    private final String uniqueId;
     private final Enum<?> errorCode;
     private final HttpStatus status;
     private final Map<String, Object> parameters;
 
     public RestException(Enum<?> errorCode, String message, HttpStatus status, Map<String, Object> parameters) {
         super(message);
+        this.uniqueId = UUID.randomUUID().toString();
         this.errorCode = errorCode;
         this.status = status;
         this.parameters = parameters;
@@ -18,6 +20,7 @@ public class RestException extends RuntimeException {
 
     public RestException(Enum<?> errorCode, String message, HttpStatus status) {
         super(message);
+        this.uniqueId = UUID.randomUUID().toString();
         this.errorCode = errorCode;
         this.status = status;
         this.parameters = Map.of();
@@ -28,7 +31,7 @@ public class RestException extends RuntimeException {
     }
 
     public String getUniqueId() {
-        return UUID.randomUUID().toString();
+        return uniqueId;
     }
 
     public Enum<?> getErrorCode() {


### PR DESCRIPTION
## Summary
- store a `uniqueId` per `RestException`

## Testing
- `gradle test` *(fails: Plugin [id: 'io.spring.dependency-management', version: '1.1.7'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449d333d608328a158c1741fa6e9fd