### PR TITLE
Add MIT license and reference in README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -12,5 +12,9 @@ Repo
   - MCP server built using Spring AI
 - [chat-flux-server](./chat-flux-server)
   - Chat server built using Spring AI
-- [mcp-tool](./mcp-tool)
-  - Tool to make MCP tool requests, to help understand the protocol
+  - [mcp-tool](./mcp-tool)
+    - Tool to make MCP tool requests, to help understand the protocol
+
+## License
+
+This project is licensed under the [MIT License](./LICENSE).


### PR DESCRIPTION
## Summary
- add MIT license file at repo root
- document license in README

## Testing
- `nix-shell shell.nix --run "gradle test"` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a4e62ae083288cd64841a140048f