### PR TITLE
Fix CDS warning in Gradle tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,5 +22,9 @@ subprojects {
             mavenBom "io.modelcontextprotocol.sdk:mcp-bom:0.10.0"
         }
     }
+
+    tasks.withType(Test).configureEach {
+        jvmArgs '-Xshare:off'
+    }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,6 @@ java.toolchain.version=21
 springBootVersion=3.4.5
 dependencyManagementVersion=1.1.7
 
+# disable class data sharing warnings
+org.gradle.jvmargs=-Xshare:off
+


### PR DESCRIPTION
## Summary
- disable class data sharing for test JVMs
- set `org.gradle.jvmargs=-Xshare:off` in `gradle.properties`

## Testing
- `nix-shell shell.nix --run "gradle --stacktrace test --no-daemon"` *(fails: Plugin [id: 'io.spring.dependency-management', version: '1.1.7'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a98c5a9483288f31d51a0bd50682