### PR TITLE
Fix duplicate test task

### DIFF
--- a/chat-flux-server/build.gradle
+++ b/chat-flux-server/build.gradle
@@ -22,7 +22,3 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-tasks.named("test") {
-    useJUnitPlatform()
-}
-


### PR DESCRIPTION
## Summary
- remove duplicate `test` task block

## Testing
- `nix-shell shell.nix --run "./gradlew test"` *(fails: environment setup takes too long)*

------
https://chatgpt.com/codex/tasks/task_e_6844f12b8c0083288a0f327c082cc481