### PR TITLE
Remove main methods from WeatherService classes

### DIFF
--- a/chat-flux-server/src/main/java/com/cyster/flux/chat/WeatherService.java
+++ b/chat-flux-server/src/main/java/com/cyster/flux/chat/WeatherService.java
@@ -117,10 +117,4 @@ public class WeatherService {
             .collect(Collectors.joining("\n"));
     }
 
-    public static void main(String[] args) {
-        WeatherService client = new WeatherService();
-        System.out.println(client.getWeatherForecastByLocation(47.6062, -122.3321));
-        System.out.println(client.getAlerts("CA"));
-    }
-
-} 
+}

--- a/chat-mvp-server/src/main/java/com/cyster/mvp/chat/WeatherService.java
+++ b/chat-mvp-server/src/main/java/com/cyster/mvp/chat/WeatherService.java
@@ -117,10 +117,4 @@ public class WeatherService {
             .collect(Collectors.joining("\n"));
     }
 
-    public static void main(String[] args) {
-        WeatherService client = new WeatherService();
-        System.out.println(client.getWeatherForecastByLocation(47.6062, -122.3321));
-        System.out.println(client.getAlerts("CA"));
-    }
-
-} 
+}


### PR DESCRIPTION
## Summary
- remove the standalone `main` methods from WeatherService

## Testing
- `nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs`
- `nix-channel --update`
- `nix-shell shell.nix --run "gradle test"` *(fails: could not resolve plugins)*

------
https://chatgpt.com/codex/tasks/task_e_6844f12102148328958ad9bf3fa442a4