### PR TITLE
Inject tool context property

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ gradle :mcp-server:runMcpTestSse
 gradle :mcp-server:runMcpTestStdio
 ```
 
+## Configuration
+
+The `mcp-server` module reads a `tool-context.home` property to populate
+environment information returned from `ToolContextService`. The default
+`application.yml` maps this property to the `TOOL_CONTEXT_HOME` environment
+variable falling back to `HOME`:
+
+```yaml
+tool-context:
+  home: ${TOOL_CONTEXT_HOME:${HOME}}
+```
+
+You can override this value using Spring configuration or by exporting the
+`TOOL_CONTEXT_HOME` variable when running the server.
+
 ## License
 
 This project is licensed under the [MIT License](./LICENSE).

--- a/mcp-server/src/main/java/com/cyster/mcp/ToolContextService.java
+++ b/mcp-server/src/main/java/com/cyster/mcp/ToolContextService.java
@@ -3,6 +3,7 @@ package com.cyster.mcp;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.ai.mcp.McpToolUtils;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 
@@ -11,8 +12,11 @@ import org.slf4j.LoggerFactory;
 
 @Service
 public class ToolContextService {
-   
+
     private static final Logger logger = LoggerFactory.getLogger(ToolContextService.class);
+
+    @Value("${tool-context.home}")
+    private String home;
 
     @Tool(description = "Get the Model Context Protocol (MCP) Tool Context")
     public String getToolContext(ToolContext toolContext) {
@@ -32,9 +36,7 @@ public class ToolContextService {
         // McpServerSession session = exchange.getSession();
         // session.env();
 
-        // for now will pull API key from environment as work around
-        // won't work for non local server
-        String home = System.getenv("HOME");
+        // for now return configured home directory
         return "{ \"HOME\": \"" + home + "\" }";
     }
 }

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -3,3 +3,6 @@
 logging:
   level:
     root: DEBUG
+
+tool-context:
+  home: ${TOOL_CONTEXT_HOME:${HOME}}


### PR DESCRIPTION
## Summary
- inject `tool-context.home` property into `ToolContextService`
- configure `tool-context.home` in `application.yml`
- document the property in README

## Testing
- `nix-shell shell.nix --run "gradle test"` *(fails: download interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6844f11787188328a5ce56b6e14c9127