### PR TITLE
Add Spotless formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ gradle test
 gradle :mcp-app:bootJar
 gradle :mcp-server:runMcpTestSse
 gradle :mcp-server:runMcpTestStdio
+gradle spotlessApply   # formats source code using google-java-format
 ```
 
 ## Configuration

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
-    id "io.spring.dependency-management"
+    id "io.spring.dependency-management" version "1.1.7"
     id "java"
+    id "com.diffplug.spotless" version "7.0.4" apply false
 }
 
 repositories {
@@ -15,11 +16,19 @@ dependencies {
 
 subprojects {
     apply plugin: "io.spring.dependency-management"
+    apply plugin: "com.diffplug.spotless"
 
     dependencyManagement {
         imports {
             mavenBom "org.springframework.ai:spring-ai-bom:1.0.0"
             mavenBom "io.modelcontextprotocol.sdk:mcp-bom:0.10.0"
+        }
+    }
+
+    spotless {
+        java {
+            googleJavaFormat('1.17')
+            target 'src/**/*.java'
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,5 @@ java.toolchain.version=21
 # plugin versions
 springBootVersion=3.4.5
 dependencyManagementVersion=1.1.7
+spotlessVersion=7.0.4
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,7 @@ pluginManagement {
     plugins {
         id "org.springframework.boot"           version "3.4.5"
         id "io.spring.dependency-management"    version "1.1.7"
+        id "com.diffplug.spotless"              version "7.0.4"
     }
 }
 


### PR DESCRIPTION
## Summary
- add Spotless plugin version to plugin management
- enable google-java-format across subprojects
- document `spotlessApply` command in README

## Testing
- `nix-shell shell.nix --run "gradle test"` *(fails: Plugin [id: 'io.spring.dependency-management'] not found)*
- `nix-shell shell.nix --run "gradle :mcp-app:bootJar"` *(fails: Plugin [id: 'io.spring.dependency-management'] not found)*
- `nix-shell shell.nix --run "gradle :mcp-server:runMcpTestSse"` *(fails: Plugin [id: 'io.spring.dependency-management'] not found)*
- `nix-shell shell.nix --run "gradle :mcp-server:runMcpTestStdio"` *(fails: Plugin [id: 'io.spring.dependency-management'] not found)*


------
https://chatgpt.com/codex/tasks/task_e_6845020cd23c83289b959903d52d81f1