### PR TITLE
Add Ubuntu setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,10 @@ Common commands run inside the shell:
 - `gradle :mcp-server:runMcpTestStdio`
 
 These are the test commands used locally and should be executed within the Nix environment.
+
+## Ubuntu Note
+
+If you are using Ubuntu and need to install the Java and Gradle tools manually,
+`UBUNTU_SETUP.md` contains a sample script that approximates the `shell.nix`
+configuration. Building and testing this project still requires running the
+commands inside `nix-shell shell.nix`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Repo Guidelines for Codex
 
-## Nix Setup
+## Nixos 
+Nixos is the default build environment
 
 To build or test this project, first install Nix and update channels:
 
@@ -11,6 +12,13 @@ nix-channel --update
 ```
 
 Use `nix-shell shell.nix` to enter the development environment. **All** `gradle` commands must run inside this shell.
+
+## Ubuntu 
+
+If you are using Ubuntu and need to install the Java and Gradle tools manually,
+`UBUNTU_SETUP.md` contains a sample script that approximates the `shell.nix`
+configuration. Building and testing this project still requires running the
+commands inside `nix-shell shell.nix`.
 
 ## Gradle Commands
 
@@ -23,9 +31,3 @@ Common commands run inside the shell:
 
 These are the test commands used locally and should be executed within the Nix environment.
 
-## Ubuntu Note
-
-If you are using Ubuntu and need to install the Java and Gradle tools manually,
-`UBUNTU_SETUP.md` contains a sample script that approximates the `shell.nix`
-configuration. Building and testing this project still requires running the
-commands inside `nix-shell shell.nix`.

--- a/UBUNTU_SETUP.md
+++ b/UBUNTU_SETUP.md
@@ -1,0 +1,21 @@
+# Ubuntu Setup
+
+These steps approximate the dependencies declared in `shell.nix`.
+
+```bash
+sudo apt-get update
+sudo apt-get install -y openjdk-21-jdk gradle locales
+sudo locale-gen en_US.UTF-8
+sudo update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+
+# ensure Java 21 is the default
+sudo update-alternatives --config java
+sudo update-alternatives --config javac
+
+# optional: set JAVA_HOME for the current shell
+export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which javac))))
+```
+
+This installs Java 21 and the latest Gradle package available on Ubuntu. Build
+and test commands for this repository should still be executed inside
+`nix-shell shell.nix` as explained in [AGENTS.md](./AGENTS.md).


### PR DESCRIPTION
## Summary
- document how to approximate the nix shell on Ubuntu
- note that gradle commands still run inside nix-shell
- use update-alternatives to select Java 21 instead of editing `.profile`

## Testing
- `nix-shell shell.nix --run "gradle test" > /tmp/gradle-test.log 2>&1 && tail -n 20 /tmp/gradle-test.log`


------
https://chatgpt.com/codex/tasks/task_e_6845067fd2888328b850250df509c1f1