### PR TITLE
Add Spotless code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ gradle test
 gradle :mcp-app:bootJar
 gradle :mcp-server:runMcpTestSse
 gradle :mcp-server:runMcpTestStdio
+gradle spotlessCheck  # verify formatting
+gradle spotlessApply  # automatically format sources
 ```
 
 ## Configuration

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "io.spring.dependency-management"
     id "java"
+    id "com.diffplug.spotless" version "6.25.0"
 }
 
 repositories {
@@ -15,6 +16,7 @@ dependencies {
 
 subprojects {
     apply plugin: "io.spring.dependency-management"
+    apply plugin: "com.diffplug.spotless"
 
     dependencyManagement {
         imports {
@@ -25,6 +27,12 @@ subprojects {
 
     tasks.withType(Test).configureEach {
         jvmArgs '-Xshare:off'
+    }
+
+    spotless {
+        java {
+            googleJavaFormat()
+        }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,7 @@ pluginManagement {
     plugins {
         id "org.springframework.boot"           version "3.4.5"
         id "io.spring.dependency-management"    version "1.1.7"
+        id "com.diffplug.spotless"              version "6.25.0"
     }
 }
 


### PR DESCRIPTION
## Summary
- configure Spotless plugin with google-java-format
- document how to check and apply formatting

## Testing
- `gradle spotlessCheck` *(fails: some files not formatted)*
- `gradle spotlessApply`

------
https://chatgpt.com/codex/tasks/task_e_6845cad4c1808328a28a6119be5ac4b3