### PR TITLE
Generic ErrorResponse

### DIFF
--- a/chat-flux-server/src/main/java/com/cyster/flux/chat/ChatController.java
+++ b/chat-flux-server/src/main/java/com/cyster/flux/chat/ChatController.java
@@ -87,7 +87,7 @@ public class ChatController {
       @Schema(description = "Human-readable error message") String message,
       @Schema(description = "Additional information about the error")
           Map<String, Object> parameters)
-      implements ChatResult, ErrorResponse {}
+      implements ChatResult, ErrorResponse<ChatErrorCode> {}
 
   public static enum ChatErrorCode {
     @Schema(description = "Prompt was empty or missing")

--- a/chat-flux-server/src/main/java/com/cyster/flux/chat/ErrorResponse.java
+++ b/chat-flux-server/src/main/java/com/cyster/flux/chat/ErrorResponse.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 /** Interface describing an error returned to the client. */
 @Schema(name = "ErrorResponse", description = "Details about an error response")
-public interface ErrorResponse {
+public interface ErrorResponse<E extends Enum<?>> {
 
   @Schema(description = "HTTP status code of the error", example = "400")
   int httpStatusCode();
@@ -16,7 +16,7 @@ public interface ErrorResponse {
   String uniqueId();
 
   @Schema(description = "Application specific error code", example = "PROMPT_MISSING")
-  Enum<?> errorCode();
+  E errorCode();
 
   @Schema(description = "Human readable error message", example = "No prompt was specified")
   String message();

--- a/chat-flux-server/src/main/java/com/cyster/flux/chat/RestErrorResponse.java
+++ b/chat-flux-server/src/main/java/com/cyster/flux/chat/RestErrorResponse.java
@@ -7,15 +7,15 @@ import java.util.Map;
 @Schema(
     name = "RestErrorResponse",
     description = "Error body returned when a RestException is thrown")
-public record RestErrorResponse(
+public record RestErrorResponse<E extends Enum<?>>(
     @Schema(description = "HTTP status code of the error", example = "400") int httpStatusCode,
     @Schema(
             description = "Unique identifier for tracking the error",
             example = "fa1ef2c2-cb51-4b62-8887-2fa8328bc8f2")
         String uniqueId,
     @Schema(description = "Application specific error code", example = "PROMPT_MISSING")
-        Enum<?> errorCode,
+        E errorCode,
     @Schema(description = "Human readable error message", example = "No prompt was specified")
         String message,
     @Schema(description = "Additional information about the error") Map<String, Object> parameters)
-    implements ErrorResponse {}
+    implements ErrorResponse<E> {}

--- a/chat-flux-server/src/main/java/com/cyster/flux/chat/RestException.java
+++ b/chat-flux-server/src/main/java/com/cyster/flux/chat/RestException.java
@@ -4,13 +4,13 @@ import java.util.Map;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 
-public class RestException extends RuntimeException implements ErrorResponse {
+public class RestException extends RuntimeException implements ErrorResponse<Enum<?>> {
   private final String uniqueId;
   private final Enum<?> errorCode;
   private final HttpStatus status;
   private final Map<String, Object> parameters;
 
-  public RestException(ErrorResponse errorResponse) {
+  public RestException(ErrorResponse<?> errorResponse) {
     super(errorResponse.message());
     this.uniqueId = errorResponse.uniqueId();
     this.errorCode = errorResponse.errorCode();

--- a/chat-flux-server/src/main/java/com/cyster/flux/chat/RestExceptionHandler.java
+++ b/chat-flux-server/src/main/java/com/cyster/flux/chat/RestExceptionHandler.java
@@ -11,7 +11,7 @@ public class RestExceptionHandler {
   private static final Logger log = LoggerFactory.getLogger(RestExceptionHandler.class);
 
   @ExceptionHandler(RestException.class)
-  public ResponseEntity<RestErrorResponse> handle(RestException exception) {
+  public ResponseEntity<RestErrorResponse<?>> handle(RestException exception) {
     log.error(
         "RestException: {} {} {} {}",
         exception.uniqueId(),
@@ -21,7 +21,7 @@ public class RestExceptionHandler {
 
     return ResponseEntity.status(exception.httpStatusCode())
         .body(
-            new RestErrorResponse(
+            new RestErrorResponse<>(
                 exception.httpStatusCode(),
                 exception.uniqueId(),
                 exception.errorCode(),
@@ -30,7 +30,7 @@ public class RestExceptionHandler {
   }
 
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<RestErrorResponse> handleUnexpected(Exception exception) {
+  public ResponseEntity<RestErrorResponse<?>> handleUnexpected(Exception exception) {
     log.error("Unhandled exception", exception);
     RestException wrapped =
         new RestException(
@@ -38,8 +38,8 @@ public class RestExceptionHandler {
             "Internal server error",
             org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR);
 
-    RestErrorResponse body =
-        new RestErrorResponse(
+    RestErrorResponse<?> body =
+        new RestErrorResponse<>(
             wrapped.httpStatusCode(),
             wrapped.uniqueId(),
             wrapped.errorCode(),

--- a/chat-mvp-server/src/main/java/com/cyster/mvp/chat/ErrorResponse.java
+++ b/chat-mvp-server/src/main/java/com/cyster/mvp/chat/ErrorResponse.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 /** Interface describing an error returned to the client. */
 @Schema(name = "ErrorResponse", description = "Details about an error response")
-public interface ErrorResponse {
+public interface ErrorResponse<E extends Enum<?>> {
 
   @Schema(description = "HTTP status code of the error", example = "400")
   int getHttpStatusCode();
@@ -16,7 +16,7 @@ public interface ErrorResponse {
   String getUniqueId();
 
   @Schema(description = "Application specific error code", example = "PROMPT_MISSING")
-  Enum<?> getErrorCode();
+  E getErrorCode();
 
   @Schema(description = "Human readable error message", example = "No prompt was specified")
   String getMessage();

--- a/chat-mvp-server/src/main/java/com/cyster/mvp/chat/RestErrorResponse.java
+++ b/chat-mvp-server/src/main/java/com/cyster/mvp/chat/RestErrorResponse.java
@@ -7,18 +7,17 @@ import java.util.Map;
 @Schema(
     name = "RestErrorResponse",
     description = "Error body returned when a RestException is thrown")
-public record RestErrorResponse(
+public record RestErrorResponse<E extends Enum<?>>(
     @Schema(description = "HTTP status code of the error", example = "400") int httpStatusCode,
     @Schema(
             description = "Unique identifier for tracking the error",
             example = "fa1ef2c2-cb51-4b62-8887-2fa8328bc8f2")
         String uniqueId,
-    @Schema(description = "Application specific error code", example = "PROMPT_MISSING")
-        Enum<?> code,
+    @Schema(description = "Application specific error code", example = "PROMPT_MISSING") E code,
     @Schema(description = "Human readable error message", example = "No prompt was specified")
         String message,
     @Schema(description = "Additional information about the error") Map<String, Object> parameters)
-    implements ErrorResponse {
+    implements ErrorResponse<E> {
 
   @Override
   public int getHttpStatusCode() {
@@ -31,7 +30,7 @@ public record RestErrorResponse(
   }
 
   @Override
-  public Enum<?> getErrorCode() {
+  public E getErrorCode() {
     return code;
   }
 

--- a/chat-mvp-server/src/main/java/com/cyster/mvp/chat/RestException.java
+++ b/chat-mvp-server/src/main/java/com/cyster/mvp/chat/RestException.java
@@ -4,7 +4,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 
-public class RestException extends Exception implements ErrorResponse {
+public class RestException extends Exception implements ErrorResponse<Enum<?>> {
   private final Enum<?> errorCode;
   private final HttpStatus status;
   private final Map<String, Object> parameters;

--- a/chat-mvp-server/src/main/java/com/cyster/mvp/chat/RestExceptionHandler.java
+++ b/chat-mvp-server/src/main/java/com/cyster/mvp/chat/RestExceptionHandler.java
@@ -11,7 +11,7 @@ public class RestExceptionHandler {
   private static final Logger log = LoggerFactory.getLogger(RestExceptionHandler.class);
 
   @ExceptionHandler(RestException.class)
-  public ResponseEntity<RestErrorResponse> handle(RestException exception) {
+  public ResponseEntity<RestErrorResponse<?>> handle(RestException exception) {
     log.error(
         "RestException: {} {} {} {}",
         exception.getUniqueId(),
@@ -21,7 +21,7 @@ public class RestExceptionHandler {
 
     return ResponseEntity.status(exception.getHttpStatusCode())
         .body(
-            new RestErrorResponse(
+            new RestErrorResponse<>(
                 exception.getHttpStatusCode(),
                 exception.getUniqueId(),
                 exception.getErrorCode(),
@@ -30,7 +30,7 @@ public class RestExceptionHandler {
   }
 
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<RestErrorResponse> handleUnexpected(Exception exception) {
+  public ResponseEntity<RestErrorResponse<?>> handleUnexpected(Exception exception) {
     log.error("Unhandled exception", exception);
     RestException wrapped =
         new RestException(
@@ -38,8 +38,8 @@ public class RestExceptionHandler {
             "Internal server error",
             org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR);
 
-    RestErrorResponse body =
-        new RestErrorResponse(
+    RestErrorResponse<?> body =
+        new RestErrorResponse<>(
             wrapped.getHttpStatusCode(),
             wrapped.getUniqueId(),
             wrapped.getErrorCode(),


### PR DESCRIPTION
## Summary
- change `ErrorResponse` to a generic interface in both chat modules
- adapt `RestErrorResponse`, `RestException`, and related handlers
- update controller error response record to implement `ErrorResponse<ChatErrorCode>`

## Testing
- `gradle test`
- `gradle spotlessCheck`


------
https://chatgpt.com/codex/tasks/task_e_6845e7855a788328aa68f477dcbee9a4