### PR TITLE
Add structured weather responses

### DIFF
--- a/weather/src/main/java/com/cyster/weather/model/AlertResponse.java
+++ b/weather/src/main/java/com/cyster/weather/model/AlertResponse.java
@@ -1,0 +1,20 @@
+package com.cyster.weather.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * Response returned from {@link com.cyster.weather.service.WeatherService} when requesting alerts.
+ */
+@Schema(description = "Weather alerts response")
+public record AlertResponse(@Schema(description = "Active alerts") List<Alert> alerts) {
+
+  /** Information about a single alert. */
+  @Schema(description = "Alert details")
+  public record Alert(
+      @Schema(description = "Event name", example = "Flood Warning") String event,
+      @Schema(description = "Area description") String area,
+      @Schema(description = "Severity level", example = "Severe") String severity,
+      @Schema(description = "Alert description") String description,
+      @Schema(description = "Safety instructions") String instruction) {}
+}

--- a/weather/src/main/java/com/cyster/weather/model/ForecastResponse.java
+++ b/weather/src/main/java/com/cyster/weather/model/ForecastResponse.java
@@ -1,0 +1,23 @@
+package com.cyster.weather.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * Response returned from {@link com.cyster.weather.service.WeatherService} when requesting a
+ * forecast.
+ */
+@Schema(description = "Weather forecast response")
+public record ForecastResponse(
+    @Schema(description = "Forecast periods") List<ForecastPeriod> periods) {
+
+  /** Forecast details for a single time period. */
+  @Schema(description = "Forecast information for a period")
+  public record ForecastPeriod(
+      @Schema(description = "Name of the period", example = "Tonight") String name,
+      @Schema(description = "Temperature value") Integer temperature,
+      @Schema(description = "Temperature units", example = "F") String temperatureUnit,
+      @Schema(description = "Wind speed", example = "5 mph") String windSpeed,
+      @Schema(description = "Wind direction", example = "NW") String windDirection,
+      @Schema(description = "Detailed forecast text") String detailedForecast) {}
+}

--- a/weather/src/main/java/com/cyster/weather/service/WeatherService.java
+++ b/weather/src/main/java/com/cyster/weather/service/WeatherService.java
@@ -1,7 +1,25 @@
 package com.cyster.weather.service;
 
-public interface WeatherService {
-  String getWeatherForecastByLocation(double latitude, double longitude);
+import com.cyster.weather.model.AlertResponse;
+import com.cyster.weather.model.ForecastResponse;
 
-  String getAlerts(String state);
+/** Service used to retrieve weather information from the NOAA API. */
+public interface WeatherService {
+
+  /**
+   * Return the weather forecast for the specified location.
+   *
+   * @param latitude latitude of the location
+   * @param longitude longitude of the location
+   * @return forecast information
+   */
+  ForecastResponse getWeatherForecastByLocation(double latitude, double longitude);
+
+  /**
+   * Return active alerts for the specified US state.
+   *
+   * @param state two letter state code
+   * @return alert information
+   */
+  AlertResponse getAlerts(String state);
 }

--- a/weather/weather-tool/src/main/java/com/cyster/weather/tool/WeatherTools.java
+++ b/weather/weather-tool/src/main/java/com/cyster/weather/tool/WeatherTools.java
@@ -1,5 +1,7 @@
 package com.cyster.weather.tool;
 
+import com.cyster.weather.model.AlertResponse;
+import com.cyster.weather.model.ForecastResponse;
 import com.cyster.weather.service.WeatherService;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.stereotype.Component;
@@ -14,14 +16,14 @@ public class WeatherTools {
   }
 
   @Tool(description = "Get weather forecast for a specific latitude/longitude")
-  public String getWeatherForecastByLocation(double latitude, double longitude) {
+  public ForecastResponse getWeatherForecastByLocation(double latitude, double longitude) {
     return weatherService.getWeatherForecastByLocation(latitude, longitude);
   }
 
   @Tool(
       description =
           "Get weather alerts for a US state. Input is Two-letter US state code(e.g. CA, NY)")
-  public String getAlerts(String state) {
+  public AlertResponse getAlerts(String state) {
     return weatherService.getAlerts(state);
   }
 }


### PR DESCRIPTION
## Summary
- add `ForecastResponse` and `AlertResponse` records for JSON responses
- return these response objects from `WeatherService` and `WeatherServiceImpl`
- update `WeatherTools` to use the new response types

## Testing
- `gradle test`
- `gradle spotlessCheck`


------
https://chatgpt.com/codex/tasks/task_e_6845fd8b7cb08328bcab7a11b86bdbbb