### PR TITLE
Extract Rest module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,20 @@
-plugins {
-    id "io.spring.dependency-management"
-    id "java"
-    id "com.diffplug.spotless" version "6.25.0"
+buildscript {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "io.spring.gradle:dependency-management-plugin:1.1.7"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"
+    }
 }
+
+plugins {
+    id "java"
+}
+
+apply plugin: "io.spring.dependency-management"
+apply plugin: "com.diffplug.spotless"
 
 repositories {
     mavenCentral()
@@ -15,8 +27,8 @@ dependencies {
 }
 
 subprojects {
-    apply plugin: "io.spring.dependency-management"
-    apply plugin: "com.diffplug.spotless"
+    pluginManager.apply("io.spring.dependency-management")
+    pluginManager.apply("com.diffplug.spotless")
 
     dependencyManagement {
         imports {

--- a/chat-server/build.gradle
+++ b/chat-server/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation 'org.springframework.ai:spring-ai-autoconfigure-model-chat-client'
     implementation 'org.springframework.ai:spring-ai-starter-model-openai'
     implementation 'org.springframework.ai:spring-ai-autoconfigure-model-openai'
+    implementation project(':rest')
     implementation 'io.modelcontextprotocol.sdk:mcp'
     implementation 'io.modelcontextprotocol.sdk:mcp-spring-webflux'
     implementation project(':weather')

--- a/chat-server/src/main/java/com/cyster/flux/chat/ChatController.java
+++ b/chat-server/src/main/java/com/cyster/flux/chat/ChatController.java
@@ -1,12 +1,12 @@
 package com.cyster.flux.chat;
 
+import com.cyster.rest.ErrorResponse;
+import com.cyster.rest.RestException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import com.cyster.rest.ErrorResponse;
-import com.cyster.rest.RestException;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.tool.ToolCallbackProvider;

--- a/chat-server/src/main/java/com/cyster/flux/chat/ChatController.java
+++ b/chat-server/src/main/java/com/cyster/flux/chat/ChatController.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import com.cyster.rest.ErrorResponse;
+import com.cyster.rest.RestException;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.tool.ToolCallbackProvider;

--- a/chat-server/src/main/java/com/cyster/flux/chat/ChatServer.java
+++ b/chat-server/src/main/java/com/cyster/flux/chat/ChatServer.java
@@ -3,6 +3,7 @@ package com.cyster.flux.chat;
 import com.cyster.weather.WeatherServicePackageMarker;
 import com.cyster.weather.tool.WeatherToolPackageMarker;
 import com.cyster.weather.tool.WeatherTools;
+import com.cyster.rest.RestPackageMarker;
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.ai.tool.method.MethodToolCallbackProvider;
 import org.springframework.boot.SpringApplication;
@@ -13,7 +14,8 @@ import org.springframework.context.annotation.Bean;
     scanBasePackageClasses = {
       ChatServer.class,
       WeatherServicePackageMarker.class,
-      WeatherToolPackageMarker.class
+      WeatherToolPackageMarker.class,
+      RestPackageMarker.class
     })
 public class ChatServer {
   public static void main(String[] args) {

--- a/chat-server/src/main/java/com/cyster/flux/chat/ChatServer.java
+++ b/chat-server/src/main/java/com/cyster/flux/chat/ChatServer.java
@@ -1,9 +1,9 @@
 package com.cyster.flux.chat;
 
+import com.cyster.rest.RestPackageMarker;
 import com.cyster.weather.WeatherServicePackageMarker;
 import com.cyster.weather.tool.WeatherToolPackageMarker;
 import com.cyster.weather.tool.WeatherTools;
-import com.cyster.rest.RestPackageMarker;
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.ai.tool.method.MethodToolCallbackProvider;
 import org.springframework.boot.SpringApplication;

--- a/chat-server/src/test/java/com/cyster/flux/chat/ChatExceptionHandlerTest.java
+++ b/chat-server/src/test/java/com/cyster/flux/chat/ChatExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package com.cyster.flux.chat;
 
+import com.cyster.rest.RestExceptionHandler;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.tool.ToolCallbackProvider;
@@ -9,7 +10,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
-import com.cyster.rest.RestExceptionHandler;
 
 @WebFluxTest(ChatController.class)
 @Import(RestExceptionHandler.class)

--- a/chat-server/src/test/java/com/cyster/flux/chat/ChatExceptionHandlerTest.java
+++ b/chat-server/src/test/java/com/cyster/flux/chat/ChatExceptionHandlerTest.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import com.cyster.rest.RestExceptionHandler;
 
 @WebFluxTest(ChatController.class)
 @Import(RestExceptionHandler.class)

--- a/chat-server/src/test/java/com/cyster/flux/chat/UnknownEndpointTest.java
+++ b/chat-server/src/test/java/com/cyster/flux/chat/UnknownEndpointTest.java
@@ -1,5 +1,6 @@
 package com.cyster.flux.chat;
 
+import com.cyster.rest.RestWebExceptionHandler;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.tool.ToolCallbackProvider;
@@ -8,7 +9,6 @@ import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
-import com.cyster.rest.RestWebExceptionHandler;
 
 @WebFluxTest(ChatController.class)
 @Import(RestWebExceptionHandler.class)

--- a/chat-server/src/test/java/com/cyster/flux/chat/UnknownEndpointTest.java
+++ b/chat-server/src/test/java/com/cyster/flux/chat/UnknownEndpointTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import com.cyster.rest.RestWebExceptionHandler;
 
 @WebFluxTest(ChatController.class)
 @Import(RestWebExceptionHandler.class)

--- a/rest/build.gradle
+++ b/rest/build.gradle
@@ -7,3 +7,13 @@ java {
         languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
+
+dependencies {
+    // explicit Spring Framework versions for this standalone module
+    implementation 'org.springframework:spring-webflux:6.1.6'
+    implementation 'org.springframework:spring-context:6.1.6'
+    implementation 'org.springframework.boot:spring-boot:3.4.5'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    implementation 'org.slf4j:slf4j-api:2.0.13'
+    implementation 'io.swagger.core.v3:swagger-annotations:2.2.21'
+}

--- a/rest/build.gradle
+++ b/rest/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'java-library'
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}

--- a/rest/build.gradle
+++ b/rest/build.gradle
@@ -16,4 +16,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation 'org.slf4j:slf4j-api:2.0.13'
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.21'
+    implementation 'io.swagger.core.v3:swagger-models:2.2.21'
+    implementation 'org.springdoc:springdoc-openapi-starter-common:2.8.3'
 }

--- a/rest/src/main/java/com/cyster/rest/ErrorResponse.java
+++ b/rest/src/main/java/com/cyster/rest/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.cyster.flux.chat;
+package com.cyster.rest;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Map;

--- a/rest/src/main/java/com/cyster/rest/GlobalErrorCode.java
+++ b/rest/src/main/java/com/cyster/rest/GlobalErrorCode.java
@@ -1,4 +1,4 @@
-package com.cyster.flux.chat;
+package com.cyster.rest;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/rest/src/main/java/com/cyster/rest/RestErrorResponse.java
+++ b/rest/src/main/java/com/cyster/rest/RestErrorResponse.java
@@ -1,4 +1,4 @@
-package com.cyster.flux.chat;
+package com.cyster.rest;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Map;

--- a/rest/src/main/java/com/cyster/rest/RestException.java
+++ b/rest/src/main/java/com/cyster/rest/RestException.java
@@ -1,4 +1,4 @@
-package com.cyster.flux.chat;
+package com.cyster.rest;
 
 import java.util.Map;
 import java.util.UUID;

--- a/rest/src/main/java/com/cyster/rest/RestExceptionDocumentationConfig.java
+++ b/rest/src/main/java/com/cyster/rest/RestExceptionDocumentationConfig.java
@@ -1,4 +1,4 @@
-package com.cyster.flux.chat;
+package com.cyster.rest;
 
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Content;

--- a/rest/src/main/java/com/cyster/rest/RestExceptionHandler.java
+++ b/rest/src/main/java/com/cyster/rest/RestExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.cyster.flux.chat;
+package com.cyster.rest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/rest/src/main/java/com/cyster/rest/RestPackageMarker.java
+++ b/rest/src/main/java/com/cyster/rest/RestPackageMarker.java
@@ -1,0 +1,6 @@
+package com.cyster.rest;
+
+/** Marker class for component scanning of the rest module. */
+public final class RestPackageMarker {
+  private RestPackageMarker() {}
+}

--- a/rest/src/main/java/com/cyster/rest/RestWebExceptionHandler.java
+++ b/rest/src/main/java/com/cyster/rest/RestWebExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.cyster.flux.chat;
+package com.cyster.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,7 @@ dependencyResolutionManagement {
 rootProject.name = "mcp"
 include "mcp-server"
 include "chat-server"
+include "rest"
 include "mcp-tool"
 include "weather"
 include "weather:weather-tool"


### PR DESCRIPTION
## Summary
- create new `rest` module for common Rest utilities
- move error handling classes from `chat-server` into the new module
- update packages and imports
- include new module in component scanning

## Testing
- `gradle test` *(fails: Plugin [id: 'io.spring.dependency-management', version: '1.1.7'] was not found)*
- `gradle spotlessCheck` *(fails: Plugin [id: 'io.spring.dependency-management', version: '1.1.7'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684611b6bfa08328a59c98cd95b7950c