### PR TITLE
Pass bearer token to tools

### DIFF
--- a/chat-server/src/main/java/com/cyster/flux/chat/ChatController.java
+++ b/chat-server/src/main/java/com/cyster/flux/chat/ChatController.java
@@ -48,6 +48,7 @@ public class ChatController {
     return chatClient
         .prompt()
         .user(request.prompt())
+        .toolContext(java.util.Map.of("bearerToken", bearerToken))
         .toolCallbacks(Arrays.asList(toolCallbackProvider.getToolCallbacks()))
         .stream()
         .content()

--- a/weather/weather-tool/src/main/java/com/cyster/weather/tool/WeatherTools.java
+++ b/weather/weather-tool/src/main/java/com/cyster/weather/tool/WeatherTools.java
@@ -3,6 +3,7 @@ package com.cyster.weather.tool;
 import com.cyster.weather.model.AlertResponse;
 import com.cyster.weather.model.ForecastResponse;
 import com.cyster.weather.service.WeatherService;
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.stereotype.Component;
 
@@ -16,14 +17,23 @@ public class WeatherTools {
   }
 
   @Tool(description = "Get weather forecast for a specific latitude/longitude")
-  public ForecastResponse getWeatherForecastByLocation(double latitude, double longitude) {
+  public ForecastResponse getWeatherForecastByLocation(
+      double latitude, double longitude, ToolContext toolContext) {
+    String bearerToken = (String) toolContext.getContext().get("bearerToken");
+    if (bearerToken == null) {
+      throw new IllegalArgumentException("bearerToken must not be null");
+    }
     return weatherService.getWeatherForecastByLocation(latitude, longitude);
   }
 
   @Tool(
       description =
           "Get weather alerts for a US state. Input is Two-letter US state code(e.g. CA, NY)")
-  public AlertResponse getAlerts(String state) {
+  public AlertResponse getAlerts(String state, ToolContext toolContext) {
+    String bearerToken = (String) toolContext.getContext().get("bearerToken");
+    if (bearerToken == null) {
+      throw new IllegalArgumentException("bearerToken must not be null");
+    }
     return weatherService.getAlerts(state);
   }
 }


### PR DESCRIPTION
## Summary
- propagate Authorization token into ChatClient context
- assert bearer token exists in `WeatherTools`

## Testing
- `gradle spotlessApply`
- `gradle spotlessCheck`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_684622e93cf4832894c491af68e45893