### PR TITLE
Remove explicit versions using BOMs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ subprojects {
         imports {
             mavenBom "org.springframework.ai:spring-ai-bom:1.0.0"
             mavenBom "io.modelcontextprotocol.sdk:mcp-bom:0.10.0"
+            mavenBom "org.springframework.boot:spring-boot-dependencies:3.5.0"
+            mavenBom "org.springdoc:springdoc-openapi-bom:2.8.9"
         }
     }
 

--- a/chat-server/build.gradle
+++ b/chat-server/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
-    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.3'
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui'
     implementation 'org.springframework.ai:spring-ai-autoconfigure-model-chat-client'
     implementation 'org.springframework.ai:spring-ai-starter-model-openai'
     implementation 'org.springframework.ai:spring-ai-autoconfigure-model-openai'
@@ -18,7 +18,7 @@ dependencies {
     implementation project(':weather:weather-tool')
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.mockito:mockito-junit-jupiter:5.18.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
 }
 
 tasks.named('test') {

--- a/mcp-tool/build.gradle
+++ b/mcp-tool/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
   implementation 'org.springframework.ai:spring-ai-starter-mcp-client'  
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+  implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'commons-cli:commons-cli:1.9.0'
 }
 

--- a/rest/build.gradle
+++ b/rest/build.gradle
@@ -10,12 +10,10 @@ java {
 
 dependencies {
     // explicit Spring Framework versions for this standalone module
-    implementation 'org.springframework:spring-webflux:6.1.6'
-    implementation 'org.springframework:spring-context:6.1.6'
-    implementation 'org.springframework.boot:spring-boot:3.4.5'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
-    implementation 'org.slf4j:slf4j-api:2.0.13'
-    implementation 'io.swagger.core.v3:swagger-annotations:2.2.21'
-    implementation 'io.swagger.core.v3:swagger-models:2.2.21'
-    implementation 'org.springdoc:springdoc-openapi-starter-common:2.8.3'
+    implementation 'org.springframework:spring-webflux'
+    implementation 'org.springframework:spring-context'
+    implementation 'org.springframework.boot:spring-boot'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.slf4j:slf4j-api'
+    implementation 'org.springdoc:springdoc-openapi-starter-common'
 }

--- a/weather/build.gradle
+++ b/weather/build.gradle
@@ -10,8 +10,8 @@ java {
 
 dependencies {
     // explicit Spring Framework versions are required for this standalone module
-    implementation 'org.springframework:spring-web:6.1.6'
-    implementation 'org.springframework:spring-context:6.1.6'
-    implementation 'org.springframework.ai:spring-ai-model:1.0.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    implementation 'org.springframework:spring-web'
+    implementation 'org.springframework:spring-context'
+    implementation 'org.springframework.ai:spring-ai-model'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 }


### PR DESCRIPTION
## Summary
- use Spring Boot BOM alongside the existing Spring AI and MCP BOMs
- clean up subproject `build.gradle` files to rely on the BOMs instead of explicit versions
- add Springdoc BOM and drop remaining springdoc versions

## Testing
- `gradle test`
- `gradle spotlessCheck`


------
https://chatgpt.com/codex/tasks/task_e_684e053291048328a155c6a82f5a8bfc